### PR TITLE
상품 검색 화면 구현

### DIFF
--- a/app/src/main/java/com/example/commerceapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/MainActivity.kt
@@ -7,10 +7,12 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -18,13 +20,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.navigation.NavController
-import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import androidx.navigation.navArgument
 import com.example.commerceapp.ui.theme.CommerceAppTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -91,25 +90,32 @@ fun BottomNavigationBar(
     items: List<BottomNavigationScreen>
 ) {
     val currentRoute = navController.currentDestination?.route ?: items.firstOrNull()
-    Row(
+    Surface(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp)
-            .zIndex(1f),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically
+            .height(56.dp),
+        shadowElevation = 8.dp
     ) {
-        items.forEach {
-            NavigationBarItem(
-                selected = currentRoute == it.route,
-                onClick = { navController.navigate(it.route) },
-                icon = {
-                    Icon(
-                        painter = painterResource(id = it.iconResourceId),
-                        contentDescription = stringResource(id = it.stringResourceId)
-                    )
-                }
-            )
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp)
+                .background(Color.White),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            items.forEach {
+                NavigationBarItem(
+                    selected = currentRoute == it.route,
+                    onClick = { navController.navigate(it.route) },
+                    icon = {
+                        Icon(
+                            painter = painterResource(id = it.iconResourceId),
+                            contentDescription = stringResource(id = it.stringResourceId)
+                        )
+                    }
+                )
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/commerceapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/MainActivity.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import androidx.navigation.NavController
 import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
@@ -94,7 +95,7 @@ fun BottomNavigationBar(
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 16.dp)
-            .background(Color.White),
+            .zIndex(1f),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically
     ) {

--- a/app/src/main/java/com/example/commerceapp/ui/MainActivity.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/MainActivity.kt
@@ -57,13 +57,21 @@ fun BottomNavigation() {
             startDestination = BottomNavigationScreen.Home.route
         ) {
             composable(BottomNavigationScreen.Home.route) { HomeScreen(navController) }
-            composable(BottomNavigationScreen.Search.route) { SearchScreen() }
+            composable(BottomNavigationScreen.Search.route) { SearchScreen(navController) }
             composable(BottomNavigationScreen.Profile.route) { ProfileScreen() }
             composable("product/{productNo}") { navBackStackEntry ->
                 navBackStackEntry.arguments?.getString("productNo")?.let {
                     ProductScreen(
                         navController = navController,
                         productNo = it
+                    )
+                } ?: ErrorScreen()
+            }
+            composable("search/{keyword}") { navBackStackEntry ->
+                navBackStackEntry.arguments?.getString("keyword")?.let {
+                    SearchResultScreen(
+                        navController = navController,
+                        keyword = it
                     )
                 } ?: ErrorScreen()
             }

--- a/app/src/main/java/com/example/commerceapp/ui/SearchResultScreen.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchResultScreen.kt
@@ -1,0 +1,147 @@
+package com.example.commerceapp.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.example.commerceapp.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchResultScreen(navController: NavController, keyword: String) {
+    val viewModel: SearchResultViewModel = hiltViewModel()
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val onItemClick = { path: String -> navController.navigate("product/${path}") }
+    val focusRequester = remember { FocusRequester() }
+    LaunchedEffect(Unit) {
+        if (keyword.isNullOrBlank()) {
+            focusRequester.requestFocus()
+        } else {
+            viewModel.updateKeyword(keyword)
+        }
+        viewModel.fetchProducts(keyword = keyword)
+    }
+    LazyColumn(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Top
+    ) {
+
+        item {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(8.dp)
+                    .height(dimensionResource(id = androidx.appcompat.R.dimen.abc_action_bar_default_height_material)),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = { navController.navigateUp() }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic__left_arrow),
+                        contentDescription = "뒤로가기"
+                    )
+                }
+
+                TextField(
+                    value = uiState.value.query,
+                    onValueChange = { text ->
+                        viewModel.updateKeyword(text)
+                    },
+                    textStyle = TextStyle(
+                        textDecoration = TextDecoration.None
+                    ),
+                    colors = TextFieldDefaults.textFieldColors(
+                        focusedIndicatorColor = Color.Transparent,
+                        unfocusedIndicatorColor = Color.Transparent
+                    ),
+                    modifier = Modifier.focusRequester(focusRequester)
+                )
+
+                IconButton(onClick = { viewModel.fetchProducts(uiState.value.query) }) {
+                    Icon(
+                        painter = painterResource(id = R.drawable.ic__search),
+                        contentDescription = "검색"
+                    )
+                }
+            }
+        }
+
+        if (uiState.value.products.isNotEmpty()) {
+            uiState.value.products.forEach { rowProducts ->
+                item(rowProducts) {
+                    HomeItemRow(row = rowProducts, onItemClick = onItemClick)
+                }
+            }
+        } else {
+            item(uiState.value.products) { EmptyProductList() }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+@Preview(showBackground = true)
+fun prevSearchResult() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(8.dp)
+            .height(dimensionResource(id = androidx.appcompat.R.dimen.abc_action_bar_default_height_material)),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        IconButton(onClick = { }) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic__left_arrow),
+                contentDescription = "뒤로가기"
+            )
+        }
+
+        // Page title
+        TextField(
+            value = "텍스트",
+            onValueChange = { text ->
+
+            },
+            textStyle = TextStyle(
+                textDecoration = TextDecoration.None
+            ),
+            colors = TextFieldDefaults.textFieldColors(
+                focusedIndicatorColor = Color.Transparent,
+                unfocusedIndicatorColor = Color.Transparent
+            ),
+        )
+
+        IconButton(onClick = { }) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic__search),
+                contentDescription = "검색"
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/example/commerceapp/ui/SearchResultScreen.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchResultScreen.kt
@@ -45,16 +45,15 @@ fun SearchResultScreen(
         if (keyword.isNullOrBlank()) {
             focusRequester.requestFocus()
         } else {
-            viewModel.updateKeyword(keyword)
-            viewModel.fetchProducts(keyword = keyword)
+            viewModel.searchByKeyword(keyword)
         }
     }
     Column {
         SearchAppbar(
             query = uiState.value.query,
-            onChange = { text -> viewModel.updateKeyword(text) },
+            onChange = { text -> viewModel.searchByKeyword(text) },
             onLeftIconClick = { navController.navigateUp() },
-            submit = { text -> viewModel.fetchProducts(text) },
+            submit = { text -> viewModel.searchByKeyword(text) },
             focusRequester = focusRequester
         )
         LazyColumn(

--- a/app/src/main/java/com/example/commerceapp/ui/SearchResultViewModel.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchResultViewModel.kt
@@ -1,0 +1,64 @@
+package com.example.commerceapp.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.commerceapp.domain.model.common.ResultEntity
+import com.example.commerceapp.domain.model.common.request.ProductSearchParam
+import com.example.commerceapp.domain.model.product.ProductPreview
+import com.example.commerceapp.domain.usecases.product.SearchProductsUseCase
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchResultViewModel @Inject constructor(
+    private val searchProduct: SearchProductsUseCase,
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(SearchUiState("", false, emptyList()))
+    val uiState: StateFlow<SearchUiState> = _uiState
+
+    fun updateKeyword(input: String) {
+        _uiState.value = uiState.value.copy(query = input)
+    }
+
+    fun fetchProducts(keyword: String = "", page: Int = 1) {
+        if (keyword.isNullOrBlank()) return
+        viewModelScope.launch {
+            _uiState.value = uiState.value.copy(isLoading = true)
+            searchProduct.invoke(
+                ProductSearchParam(
+                    keyword = keyword,
+                    page = page,
+                    pagePerSize = 20
+                )
+            ).collectLatest {
+                when (it) {
+                    is ResultEntity.Success -> {
+                        _uiState.value = uiState.value.copy(
+                            isLoading = false,
+                            products = it.data.chunked(2)
+                        )
+                    }
+
+                    is ResultEntity.Error -> {
+                        _uiState.value = uiState.value.copy(
+                            isLoading = false
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    data class SearchUiState(
+        val query: String,
+        val isLoading: Boolean,
+        val products: List<List<ProductPreview>>,
+    )
+}
+
+

--- a/app/src/main/java/com/example/commerceapp/ui/SearchResultViewModel.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchResultViewModel.kt
@@ -25,7 +25,10 @@ class SearchResultViewModel @Inject constructor(
         _uiState.value = uiState.value.copy(query = input)
     }
 
-    fun fetchProducts(keyword: String = "", page: Int = 1) {
+    fun fetchProducts(
+        keyword: String = "",
+        page: Int = 1
+    ) {
         if (keyword.isNullOrBlank()) return
         viewModelScope.launch {
             _uiState.value = uiState.value.copy(isLoading = true)

--- a/app/src/main/java/com/example/commerceapp/ui/SearchResultViewModel.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchResultViewModel.kt
@@ -7,6 +7,7 @@ import com.example.commerceapp.domain.model.common.request.ProductSearchParam
 import com.example.commerceapp.domain.model.product.ProductPreview
 import com.example.commerceapp.domain.usecases.product.SearchProductsUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -21,17 +22,17 @@ class SearchResultViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(SearchUiState("", false, emptyList()))
     val uiState: StateFlow<SearchUiState> = _uiState
 
-    fun updateKeyword(input: String) {
-        _uiState.value = uiState.value.copy(query = input)
-    }
+    var searchJob: Job? = null
 
-    fun fetchProducts(
+    fun searchByKeyword(
         keyword: String = "",
         page: Int = 1
     ) {
+        _uiState.value = uiState.value.copy(query = keyword)
         if (keyword.isNullOrBlank()) return
-        viewModelScope.launch {
-            _uiState.value = uiState.value.copy(isLoading = true)
+        searchJob?.cancel()
+        _uiState.value = uiState.value.copy(isLoading = true)
+        searchJob = viewModelScope.launch {
             searchProduct.invoke(
                 ProductSearchParam(
                     keyword = keyword,

--- a/app/src/main/java/com/example/commerceapp/ui/SearchScreen.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchScreen.kt
@@ -1,0 +1,136 @@
+package com.example.commerceapp.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.SuggestionChip
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.res.colorResource
+import androidx.compose.ui.res.dimensionResource
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.PlatformTextStyle
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.LineHeightStyle
+import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.TextUnitType
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavController
+import com.example.commerceapp.R
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SearchScreen(navController: NavController) {
+    val viewModel: SearchViewModel = hiltViewModel()
+    val uiState = viewModel.uiState.collectAsStateWithLifecycle()
+    val onItemClick = { path: String -> navController.navigate("search/${path}") }
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Top
+    ) {
+
+        Box(
+            modifier = Modifier
+                .height(dimensionResource(id = androidx.appcompat.R.dimen.abc_action_bar_default_height_material))
+                .padding(8.dp)
+                .fillMaxWidth()
+        ) {
+            searchBar(onItemClick)
+        }
+        Column(Modifier.padding(8.dp)) {
+
+            clips(title = "최근 검색어", list = uiState.value.recent, onClick = onItemClick)
+
+            clips(title = "추천 검색어", list = uiState.value.recommends, onClick = onItemClick)
+        }
+    }
+
+}
+
+@Composable
+fun searchBar(onItemClick: (String) -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(start = 8.dp, end = 8.dp)
+            .background(colorResource(id = R.color.gray_02))
+            .clip(RoundedCornerShape(8.dp))
+            .clickable {
+                onItemClick(" ")
+            },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = "검색어를 입력하세요",
+            style = TextStyle(
+                lineHeight = TextUnit(2.5f, TextUnitType.Em),
+                platformStyle = PlatformTextStyle(includeFontPadding = false),
+                lineHeightStyle = LineHeightStyle(
+                    alignment = LineHeightStyle.Alignment.Center,
+                    trim = LineHeightStyle.Trim.Both
+                )
+            ),
+            modifier = Modifier
+                .weight(1f)
+                .padding(8.dp),
+        )
+        IconButton(onClick = { onItemClick(" ") }) {
+            Icon(
+                painter = painterResource(id = R.drawable.ic__search),
+                contentDescription = "검색"
+            )
+        }
+    }
+}
+
+@Composable
+fun clips(title: String, list: List<String>, onClick: (String) -> Unit) {
+    Column {
+        Text(
+            text = title,
+            style = TextStyle(
+                fontSize = 18.sp,
+                fontWeight = FontWeight.Bold
+            ),
+            color = colorResource(id = R.color.text_black),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, bottom = 8.dp)
+        )
+        LazyRow(
+            Modifier
+                .fillMaxWidth()
+                .padding(top = 8.dp, bottom = 8.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(list) {
+                SuggestionChip(
+                    onClick = { onClick(it) },
+                    label = { Text(text = it) },
+                    shape = RoundedCornerShape(50)
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/commerceapp/ui/SearchScreen.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchScreen.kt
@@ -22,8 +22,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.colorResource
-import androidx.compose.ui.res.dimensionResource
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.PlatformTextStyle
 import androidx.compose.ui.text.TextStyle
@@ -45,30 +45,31 @@ fun SearchScreen(navController: NavController) {
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val onItemClick = { path: String -> navController.navigate("search/${path}") }
     Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Top
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.White),
+        verticalArrangement = Arrangement.Top,
     ) {
 
         Box(
             modifier = Modifier
-                .height(dimensionResource(id = androidx.appcompat.R.dimen.abc_action_bar_default_height_material))
+                .height(56.dp)
                 .padding(8.dp)
                 .fillMaxWidth()
         ) {
-            searchBar(onItemClick)
+            SearchBar(onItemClick)
         }
         Column(Modifier.padding(8.dp)) {
 
-            clips(title = "최근 검색어", list = uiState.value.recent, onClick = onItemClick)
+            Clips(title = "최근 검색어", list = uiState.value.recent, onClick = onItemClick)
 
-            clips(title = "추천 검색어", list = uiState.value.recommends, onClick = onItemClick)
+            Clips(title = "추천 검색어", list = uiState.value.recommends, onClick = onItemClick)
         }
     }
-
 }
 
 @Composable
-fun searchBar(onItemClick: (String) -> Unit) {
+fun SearchBar(onItemClick: (String) -> Unit) {
     Row(
         modifier = Modifier
             .fillMaxSize()
@@ -105,7 +106,11 @@ fun searchBar(onItemClick: (String) -> Unit) {
 }
 
 @Composable
-fun clips(title: String, list: List<String>, onClick: (String) -> Unit) {
+fun Clips(
+    title: String,
+    list: List<String>,
+    onClick: (String) -> Unit
+) {
     Column {
         Text(
             text = title,

--- a/app/src/main/java/com/example/commerceapp/ui/SearchViewModel.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchViewModel.kt
@@ -4,7 +4,6 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.example.commerceapp.domain.model.common.ResultEntity
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -40,7 +39,6 @@ class SearchViewModel @Inject constructor() : ViewModel() {
             started = SharingStarted.WhileSubscribed()
         )
 
-
     private val flowRecommends = flow<ResultEntity<List<String>>> {
         delay(Duration.ofSeconds(1))
         emit(ResultEntity.Success(listOf("암막커튼", "마켓비", "모니터받침대", "책상", "장스탠드")))
@@ -49,7 +47,6 @@ class SearchViewModel @Inject constructor() : ViewModel() {
         delay(Duration.ofSeconds(1))
         emit(ResultEntity.Success(listOf("팜레스트", "러그", "쓰레기통", "블라인드")))
     }
-
 
     init {
         fetchRecent()
@@ -60,8 +57,7 @@ class SearchViewModel @Inject constructor() : ViewModel() {
         handleFlowResponse(
             flowRecommends,
             { _recommends.value = it },
-            { /* 에러 처리*/ },
-            viewModelScope
+            { /* 에러 처리*/ }
         )
     }
 
@@ -69,18 +65,16 @@ class SearchViewModel @Inject constructor() : ViewModel() {
         handleFlowResponse(
             flowRecent,
             { _recent.value = it },
-            { /* 에러 처리*/ },
-            viewModelScope
+            { /* 에러 처리*/ }
         )
     }
 
     private fun handleFlowResponse(
         flow: Flow<ResultEntity<List<String>>>,
         onSuccess: (List<String>) -> Unit,
-        onError: (String) -> Unit,
-        scope: CoroutineScope
+        onError: (String) -> Unit
     ) {
-        scope.launch {
+        viewModelScope.launch {
             flow.collectLatest {
                 when (it) {
                     is ResultEntity.Success -> {

--- a/app/src/main/java/com/example/commerceapp/ui/SearchViewModel.kt
+++ b/app/src/main/java/com/example/commerceapp/ui/SearchViewModel.kt
@@ -1,0 +1,103 @@
+package com.example.commerceapp.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.commerceapp.domain.model.common.ResultEntity
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.time.delay
+import java.time.Duration
+import javax.inject.Inject
+
+@HiltViewModel
+class SearchViewModel @Inject constructor() : ViewModel() {
+
+    private val _recent = MutableStateFlow<List<String>>(emptyList())
+    private val _recommends = MutableStateFlow<List<String>>(emptyList())
+    val uiState: StateFlow<SearchUiState> =
+        combine(_recent, _recommends) { recent, recommends ->
+            SearchUiState(
+                isLoading = false,
+                recent = recent,
+                recommends = recommends
+            )
+        }.stateIn(
+            scope = viewModelScope,
+            initialValue = SearchUiState(
+                true,
+                emptyList(),
+                emptyList()
+            ),
+            started = SharingStarted.WhileSubscribed()
+        )
+
+
+    private val flowRecommends = flow<ResultEntity<List<String>>> {
+        delay(Duration.ofSeconds(1))
+        emit(ResultEntity.Success(listOf("암막커튼", "마켓비", "모니터받침대", "책상", "장스탠드")))
+    }
+    private val flowRecent = flow<ResultEntity<List<String>>> {
+        delay(Duration.ofSeconds(1))
+        emit(ResultEntity.Success(listOf("팜레스트", "러그", "쓰레기통", "블라인드")))
+    }
+
+
+    init {
+        fetchRecent()
+        fetchRecommends()
+    }
+
+    private fun fetchRecommends() {
+        handleFlowResponse(
+            flowRecommends,
+            { _recommends.value = it },
+            { /* 에러 처리*/ },
+            viewModelScope
+        )
+    }
+
+    private fun fetchRecent() {
+        handleFlowResponse(
+            flowRecent,
+            { _recent.value = it },
+            { /* 에러 처리*/ },
+            viewModelScope
+        )
+    }
+
+    private fun handleFlowResponse(
+        flow: Flow<ResultEntity<List<String>>>,
+        onSuccess: (List<String>) -> Unit,
+        onError: (String) -> Unit,
+        scope: CoroutineScope
+    ) {
+        scope.launch {
+            flow.collectLatest {
+                when (it) {
+                    is ResultEntity.Success -> {
+                        onSuccess(it.data)
+                    }
+
+                    is ResultEntity.Error -> {
+                        onError(it.message)
+                    }
+                }
+            }
+        }
+    }
+
+    data class SearchUiState(
+        val isLoading: Boolean,
+        val recommends: List<String>,
+        val recent: List<String>,
+    )
+}


### PR DESCRIPTION
상품 검색 탭 내 화면 구현
- Navigation에 SearchResultScreen추가
- BottomNav에서 search클릭 시 SearchScreen으로 이동
- SearchScreen에서 최근검색어 / 추천검색어 표기(더미데이터)
- 검색창 클릭하거나 검색어 아이템 클릭 시 SearchResultScreen으로 이동
- 검색 결과 목록 아이템 클릭 시 상세화면으로 이동